### PR TITLE
Added jsonignorenull options

### DIFF
--- a/Nhea.Data.Repository.RedisRepository/Nhea.Data.Repository.RedisRepository.csproj
+++ b/Nhea.Data.Repository.RedisRepository/Nhea.Data.Repository.RedisRepository.csproj
@@ -11,9 +11,9 @@
     <PackageTags>repository, nhea, redis, cache</PackageTags>
     <PackageReleaseNotes>Added connection pooling.</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.0.8</Version>
-    <AssemblyVersion>2.0.8.0</AssemblyVersion>
-    <FileVersion>2.0.8.0</FileVersion>
+    <Version>2.0.9</Version>
+    <AssemblyVersion>2.0.9.0</AssemblyVersion>
+    <FileVersion>2.0.9.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added IgnoreNullSerialization virtual property. If it's set true, save, saveasync, publish and publishasync methods will serialize with "System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull" option.
Default value "System.Text.Json.Serialization.JsonIgnoreCondition.Never"